### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,4 +1,6 @@
 name: Angular Build and Test
+permissions:
+  contents: read
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/sharth/ancestry/security/code-scanning/2](https://github.com/sharth/ancestry/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the `GITHUB_TOKEN` permissions to the minimum required. Since the workflow only checks out code, installs dependencies, builds, and runs tests, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` field and before the `on` field. This will apply the restriction to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
