### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/sharth/ancestry/security/code-scanning/1](https://github.com/sharth/ancestry/security/code-scanning/1)

To fix the problem, add a `permissions` block to the `build` job in `.github/workflows/github-pages.yml`, explicitly setting the minimum required permissions. Since the build job only checks out code and builds the project, it only needs read access to repository contents. Therefore, set `permissions: contents: read` under the `build` job, at the same indentation level as `runs-on`. No other changes are needed, and this will not affect existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
