### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -31,6 +31,8 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/sharth/ancestry/security/code-scanning/6](https://github.com/sharth/ancestry/security/code-scanning/6)

Add an explicit `permissions` block for the `deploy` job so both jobs in this workflow have least-privilege permissions defined. The minimal non-breaking fix is to set `contents: read` in `deploy`, matching `build` and preserving behavior while preventing inherited broader defaults.

**Best single fix in this snippet:**
- File: `.github/workflows/cloudflare-pages.yml`
- Region: `jobs.deploy` (around lines 31–34)
- Change: insert
  ```yml
  permissions:
    contents: read
  ```
  directly under `runs-on` in the `deploy` job.

No imports, methods, or dependencies are required since this is YAML workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
